### PR TITLE
Use lowercase error codes

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,13 +17,13 @@ export class SAMLShieldError extends Error {
 
 export class ValidationError extends SAMLShieldError {
   constructor(reason: string) {
-    super(`Invalid input: ${reason}`, "VALIDATION_ERROR");
+    super(`Invalid input: ${reason}`, "validation_error");
   }
 }
 
 export class XMLValidationError extends SAMLShieldError {
   constructor(reason: string, details?: ErrorDetails) {
-    super(`Invalid input: ${reason}`, "XML_VALIDATION_ERROR", {
+    super(`Invalid input: ${reason}`, "xml_validation_error", {
       ...details,
       invalid_input: reason,
     });
@@ -56,7 +56,7 @@ export class SAMLExpectedAtLeastOneSignatureError extends SAMLShieldError {
   constructor() {
     super(
       "Invalid input: one of response or assertion must be signed",
-      "SAML_ASSERTION_NOT_SIGNED",
+      "saml_assertion_not_signed",
     );
   }
 }
@@ -65,7 +65,7 @@ export class XMLExternalEntitiesForbiddenError extends SAMLShieldError {
   constructor() {
     super(
       "Invalid input: External Entities are forbidden",
-      "XML_VALIDATION_ERROR",
+      "xml_validation_error",
       { invalid_input: "External Entities are forbidden" },
     );
   }
@@ -79,7 +79,7 @@ export class SAMLResponseFailureError extends SAMLShieldError {
   ) {
     super(
       "IDP was not able to complete the login as requested",
-      "SAML_LOGIN_FAILED",
+      "saml_login_failed",
       {
         response_id,
         saml_status_code,
@@ -93,13 +93,13 @@ export class SAMLAssertionExpiredError extends SAMLShieldError {
   constructor() {
     super(
       "SAML assertion expired: clocks skewed too much",
-      "SAML_ASSERTION_EXPIRED",
+      "saml_assertion_expired",
     );
   }
 }
 
 export class SAMLAssertionNotYetValidError extends SAMLShieldError {
   constructor() {
-    super("SAML assertion not yet valid", "SAML_ASSERTION_NOT_YET_VALID");
+    super("SAML assertion not yet valid", "saml_assertion_not_yet_valid");
   }
 }

--- a/test/contract/data/common_vulnerabilities/billion_laughs/billion_laughs.test.json
+++ b/test/contract/data/common_vulnerabilities/billion_laughs/billion_laughs.test.json
@@ -6,5 +6,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "Invalid input: External Entities are forbidden",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/common_vulnerabilities/comments_not_allowed_in_attribute/comments_not_allowed_in_attribute.test.json
+++ b/test/contract/data/common_vulnerabilities/comments_not_allowed_in_attribute/comments_not_allowed_in_attribute.test.json
@@ -16,5 +16,5 @@
   "mockTime": "2022-11-17T22:28:00Z",
   "shouldSucceed": false,
   "expectedError": "Invalid input: response contained illegal XML comments",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/common_vulnerabilities/comments_not_allowed_in_nameid/comments_not_allowed_in_nameid.test.json
+++ b/test/contract/data/common_vulnerabilities/comments_not_allowed_in_nameid/comments_not_allowed_in_nameid.test.json
@@ -19,5 +19,5 @@
   "mockTime": "2022-11-04T03:05:00Z",
   "shouldSucceed": false,
   "expectedError": "Invalid input: response contained illegal XML comments",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/common_vulnerabilities/embedded_comment_in_attribute/embedded_comment_in_attribute.test.json
+++ b/test/contract/data/common_vulnerabilities/embedded_comment_in_attribute/embedded_comment_in_attribute.test.json
@@ -19,5 +19,5 @@
   "mockTime": "2022-11-17T22:28:00Z",
   "shouldSucceed": false,
   "expectedError": "Invalid input: response contained illegal XML comments",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/common_vulnerabilities/embedded_comment_in_nameid/embedded_comment_in_nameid.test.json
+++ b/test/contract/data/common_vulnerabilities/embedded_comment_in_nameid/embedded_comment_in_nameid.test.json
@@ -19,5 +19,5 @@
   "mockTime": "2022-11-04T03:05:00Z",
   "shouldSucceed": false,
   "expectedError": "Invalid input: response contained illegal XML comments",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/common_vulnerabilities/error_bad_audience/error_bad_audience.test.json
+++ b/test/contract/data/common_vulnerabilities/error_bad_audience/error_bad_audience.test.json
@@ -8,5 +8,5 @@
   "skip": true,
   "shouldSucceed": false,
   "expectedError": "SAML assertion audience mismatch. Expected: INVALID sp_entity_id Received: example",
-  "expectedErrorCode": "SAML_ASSERTION_AUDIENCE_MISMATCH"
+  "expectedErrorCode": "saml_assertion_audience_mismatch"
 }

--- a/test/contract/data/common_vulnerabilities/error_no_signatures/error_no_signatures.test.json
+++ b/test/contract/data/common_vulnerabilities/error_no_signatures/error_no_signatures.test.json
@@ -10,5 +10,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "Invalid input: one of response or assertion must be signed",
-  "expectedErrorCode": "SAML_ASSERTION_NOT_SIGNED"
+  "expectedErrorCode": "saml_assertion_not_signed"
 }

--- a/test/contract/data/common_vulnerabilities/external_entity_expansion/external_entity_expansion.test.json
+++ b/test/contract/data/common_vulnerabilities/external_entity_expansion/external_entity_expansion.test.json
@@ -11,5 +11,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "Invalid input: External Entities are forbidden",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/common_vulnerabilities/not_after_already_passed/not_after_already_passed.test.json
+++ b/test/contract/data/common_vulnerabilities/not_after_already_passed/not_after_already_passed.test.json
@@ -11,5 +11,5 @@
   "mockTime": "2022-11-18T22:30:38.917Z",
   "shouldSucceed": false,
   "expectedError": "SAML assertion expired: clocks skewed too much",
-  "expectedErrorCode": "SAML_ASSERTION_EXPIRED"
+  "expectedErrorCode": "saml_assertion_expired"
 }

--- a/test/contract/data/common_vulnerabilities/not_before_already_passed/not_before_already_passed.test.json
+++ b/test/contract/data/common_vulnerabilities/not_before_already_passed/not_before_already_passed.test.json
@@ -11,5 +11,5 @@
   "mockTime": "2025-07-29T20:00:00.000Z",
   "shouldSucceed": false,
   "expectedError": "SAML assertion not yet valid",
-  "expectedErrorCode": "SAML_ASSERTION_NOT_YET_VALID"
+  "expectedErrorCode": "saml_assertion_not_yet_valid"
 }

--- a/test/contract/data/common_vulnerabilities/processing_instructions_not_allowed/processing_instructions_not_allowed.test.json
+++ b/test/contract/data/common_vulnerabilities/processing_instructions_not_allowed/processing_instructions_not_allowed.test.json
@@ -14,5 +14,5 @@
   "mockTime": "2022-11-04T03:05:00Z",
   "shouldSucceed": false,
   "expectedError": "Invalid input: response contained illegal processing instructions",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/common_vulnerabilities/quadratic_blowup/quadratic_blowup.test.json
+++ b/test/contract/data/common_vulnerabilities/quadratic_blowup/quadratic_blowup.test.json
@@ -10,5 +10,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "Invalid input: External Entities are forbidden",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/digest_vuln/digest_vuln.test.json
+++ b/test/contract/data/digest_vuln/digest_vuln.test.json
@@ -11,5 +11,5 @@
   "mockTime": "2024-12-08T09:50:00Z",
   "shouldSucceed": false,
   "expectedError": "Invalid input: response contained illegal XML comments",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/error_cases/empty_response.test.json
+++ b/test/contract/data/error_cases/empty_response.test.json
@@ -6,5 +6,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "missing required field: SAMLResponse",
-  "expectedErrorCode": "VALIDATION_ERROR"
+  "expectedErrorCode": "validation_error"
 }

--- a/test/contract/data/error_cases/invalid_xml.test.json
+++ b/test/contract/data/error_cases/invalid_xml.test.json
@@ -6,5 +6,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "document does not contain a SAML Response element",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/error_cases/missing_signature.test.json
+++ b/test/contract/data/error_cases/missing_signature.test.json
@@ -6,5 +6,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "one of response or assertion must be signed",
-  "expectedErrorCode": "SAML_ASSERTION_NOT_SIGNED"
+  "expectedErrorCode": "saml_assertion_not_signed"
 }

--- a/test/contract/data/multiple_signedinfo_nodes_vuln/multiple_signedinfo_nodes_vuln.test.json
+++ b/test/contract/data/multiple_signedinfo_nodes_vuln/multiple_signedinfo_nodes_vuln.test.json
@@ -11,5 +11,5 @@
   "mockTime": "2022-11-04T03:05:00Z",
   "shouldSucceed": false,
   "expectedError": "Invalid input: response contained multiple SignedInfo elements",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/security_validations/doctype_without_entity.test.json
+++ b/test/contract/data/security_validations/doctype_without_entity.test.json
@@ -6,5 +6,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "DOCTYPE detected and blocked",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/security_validations/forbidden_authn_request.test.json
+++ b/test/contract/data/security_validations/forbidden_authn_request.test.json
@@ -6,5 +6,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "Found 1 AuthnRequest elements. None allowed in SAML responses",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/security_validations/invalid_canonicalization_method.test.json
+++ b/test/contract/data/security_validations/invalid_canonicalization_method.test.json
@@ -7,5 +7,5 @@
   "mockTime": "2022-11-17T22:15:54.006Z",
   "shouldSucceed": false,
   "expectedError": "Invalid CanonicalizationMethod algorithm: http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/security_validations/invalid_transform_algorithm.test.json
+++ b/test/contract/data/security_validations/invalid_transform_algorithm.test.json
@@ -7,5 +7,5 @@
   "mockTime": "2022-11-17T22:15:54.006Z",
   "shouldSucceed": false,
   "expectedError": "Unexpected transform algorithm: http://malicious.com/evil-transform",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/security_validations/malformed_signature_uri.test.json
+++ b/test/contract/data/security_validations/malformed_signature_uri.test.json
@@ -7,5 +7,5 @@
   "mockTime": "2022-11-17T22:15:54.006Z",
   "shouldSucceed": false,
   "expectedError": "Malformed URI: http://evil.com/malicious",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/security_validations/multiple_assertions.test.json
+++ b/test/contract/data/security_validations/multiple_assertions.test.json
@@ -6,5 +6,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "Found 2 of Assertions/EncryptedAssertion elements. Only one allowed",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/security_validations/multiple_response_elements.test.json
+++ b/test/contract/data/security_validations/multiple_response_elements.test.json
@@ -6,5 +6,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "document contains multiple SAML Response elements",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/security_validations/nonexistent_id_reference.test.json
+++ b/test/contract/data/security_validations/nonexistent_id_reference.test.json
@@ -7,5 +7,5 @@
   "mockTime": "2022-11-17T22:15:54.006Z",
   "shouldSucceed": false,
   "expectedError": "URI references non-existent ID: nonexistent_id_reference",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/security_validations/too_many_transforms.test.json
+++ b/test/contract/data/security_validations/too_many_transforms.test.json
@@ -7,5 +7,5 @@
   "shouldSucceed": false,
   "mockTime": "2022-11-17T22:15:54.006Z",
   "expectedError": "Too many transforms: 3. Maximum 2 allowed",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/security_validations_malicious/digestvalue_location_mismatch.test.json
+++ b/test/contract/data/security_validations_malicious/digestvalue_location_mismatch.test.json
@@ -6,5 +6,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "Found 2 DigestValue elements but only 1 are in proper signature Reference context. Potential DigestValue wrapping attack detected",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/security_validations_malicious/digestvalue_wrapping_attack.test.json
+++ b/test/contract/data/security_validations_malicious/digestvalue_wrapping_attack.test.json
@@ -6,5 +6,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "Expected exactly one DigestValue per signature, found 2. Multiple DigestValues can enable wrapping attacks",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/security_validations_malicious/hmac_signature_method.test.json
+++ b/test/contract/data/security_validations_malicious/hmac_signature_method.test.json
@@ -6,5 +6,5 @@
   },
   "shouldSucceed": false,
   "expectedError": "HMAC-based SignatureMethod blocked: http://www.w3.org/2000/09/xmldsig#hmac-sha1",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/security_validations_malicious/nonexistent_id_working_base.test.json
+++ b/test/contract/data/security_validations_malicious/nonexistent_id_working_base.test.json
@@ -8,5 +8,5 @@
   "mockTime": "2022-11-17T22:10:20.006Z",
   "shouldSucceed": false,
   "expectedError": "URI references non-existent ID: nonexistent_id_reference",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/vulnerabilities/multiple_signedinfo.test.json
+++ b/test/contract/data/vulnerabilities/multiple_signedinfo.test.json
@@ -7,5 +7,5 @@
   "mockTime": "2022-11-04T03:07:29Z",
   "shouldSucceed": false,
   "expectedError": "response contained multiple SignedInfo elements in a single signature",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/vulnerabilities/processing_instructions.test.json
+++ b/test/contract/data/vulnerabilities/processing_instructions.test.json
@@ -7,5 +7,5 @@
   "mockTime": "2022-11-04T03:07:29Z",
   "shouldSucceed": false,
   "expectedError": "response contained illegal processing instructions",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }

--- a/test/contract/data/vulnerabilities/xml_comment_injection.test.json
+++ b/test/contract/data/vulnerabilities/xml_comment_injection.test.json
@@ -7,5 +7,5 @@
   "mockTime": "2022-11-22T20:25:00Z",
   "shouldSucceed": false,
   "expectedError": "response contained illegal XML comments",
-  "expectedErrorCode": "XML_VALIDATION_ERROR"
+  "expectedErrorCode": "xml_validation_error"
 }


### PR DESCRIPTION
see title.

I accidentally converted the error codes to uppercase when I was copying over the validation library from our internal library.  